### PR TITLE
Add object tracker

### DIFF
--- a/inference_utils.mjs
+++ b/inference_utils.mjs
@@ -106,33 +106,6 @@ function centerToCornersFormat([centerX, centerY, width, height]) {
   ];
 }
 
-function cropImage(imageData, boundingBox) {
-  const { data, width } = imageData;
-  const x = Math.round(boundingBox.topLeft.x * imageData.width);
-  const y = Math.round(boundingBox.topLeft.y * imageData.height);
-  const bboxWidth = Math.round(boundingBox.bottomRight.x * imageData.width - x);
-  const bboxHeight = Math.round(boundingBox.bottomRight.y* imageData.height - y);
-  const bytesPerPixel = 4;
-
-  // Create a new Uint8ClampedArray for the cropped image data
-  const croppedData = new Uint8ClampedArray(bboxWidth * bboxHeight * bytesPerPixel);
-
-  // Iterate over the rows and columns of the bounding box
-  for (let row = 0; row < bboxHeight; row++) {
-    const srcStartIndex = ((y + row) * width + x) * bytesPerPixel;
-    const destStartIndex = Math.min(row * bboxWidth * bytesPerPixel, croppedData.length - 1);
-
-    // Copy the pixels from the source image data to the cropped image data
-    croppedData.set(data.subarray(srcStartIndex, srcStartIndex + bboxWidth * bytesPerPixel), Math.min(destStartIndex, croppedData.length - 1));
-  }
-
-  return {
-    data: croppedData,
-    width: bboxWidth,
-    height: bboxHeight,
-  };
-}
-
 export function descaleCoords(x, y, originalWidth, originalHeight, scaledWidth, scaledHeight) {
   return [
     x * (originalWidth / scaledWidth) / originalWidth,
@@ -608,7 +581,7 @@ export function tensorToMatrix(tensor) {
   }
 
   const dimensions = [...tensor.dims];
-  const matrix = reshapeArray(dataArray, dimensions);
+  const matrix = reshapeArray(dataArray, tensor.dims);
   matrix.size = function() {
     return dimensions;
   };

--- a/object_tracking.mjs
+++ b/object_tracking.mjs
@@ -13,56 +13,202 @@ export class Detection {
 
 export class MixFormerObjectTracker {
   /**
-   * @param {InferenceSession} onnxModel
+   * @param {InferenceSession} onnxSession
    * @param {Object} options
    */
 
   constructor(
-    onnxModel,
+    onnxSession,
     {
       templateFactor = 2.0,
       templateSize = 112,
       searchFactor = 4.5,
       searchSize = 224,
-      updateInterval = 10,
+      updateInterval = 5,
       maxScoreDecay = 1.0,
+      minConfidenceThreshold = 0.6,
+      maxConsecutiveFailures = 3,
+      debug = false,
     } = {}
   ) {
-    this.onnxModel = onnxModel;
+    this.onnxSession = onnxSession;
     this.templateFactor = templateFactor;
     this.templateSize = templateSize;
     this.searchFactor = searchFactor;
     this.searchSize = searchSize;
     this.updateInterval = updateInterval;
     this.maxScoreDecay = maxScoreDecay;
+    this.minConfidenceThreshold = minConfidenceThreshold;
+    this.maxConsecutiveFailures = maxConsecutiveFailures;
 
-    this.state = null;
+    this.currentXywh = null;
     this.frame_id = 0;
-    this.label = null;
+    this.label = "UNKNOWN";
+    this.numConsecutiveFailures = 0;
+    this.debug = debug;
   }
 
-  sigmoid = (x) => 1 / (1 + Math.exp(-x));
+
+  /**
+   * Initialize the tracker with the initial frame
+   * @param {} image The template image
+   * @param {*} bbox The bounding-box of the object to track.
+   *                 An object with keys x1, y1, x2, y2. The values should be normalized.
+   * @param {*} label A string label to identify the object, e.g., "person-1"
+   */
+  init = async (image, bbox, label = "UNKNOWN") => {
+    // Denormalize bounding-box coordinates
+    let { x1: x, y1: y, x2: _x2, y2: _y2 } = bbox;
+    x *= image.width;
+    y *= image.height;
+    _x2 *= image.width;
+    _y2 *= image.height;
+
+    const [w, h] = [_x2 - x, _y2 - y];
+    const xywh = [x, y, w, h];
+    const [zPatchArray, _] = this._sampleTarget(
+      image,
+      xywh,
+      this.templateFactor,
+      this.templateSize
+    );
+    if (this.debug) {
+      this.rawTemplate = zPatchArray;
+      this.rawOnlineTemplate = zPatchArray;
+    }
+    const template = normalize(zPatchArray);
+    this.template = template;
+    this.onlineTemplate = template;
+
+    this.maxPredScore = -1.0;
+    this.onlineMaxTemplate = template;
+
+    // save states
+    this.numConsecutiveFailures = 0;
+    this.currentXywh = xywh;
+    this.frameId = 0;
+    this.label = label;
+  };
+
+  /**
+   * Returns true if the tracker is currently tracking an object.
+   */
+  isTracking = () => {
+    return (
+      this.currentXywh !== null &&
+      this.numConsecutiveFailures < this.maxConsecutiveFailures
+    );
+  };
+
+  /**
+   * Update the tracker with the latest image
+   * 
+   * @param {*} image The latest image
+   * @returns { detection: Detection, isTracking: boolean}
+   */
+  async update(image) {
+    if (!this.isTracking()) {
+      return { detection: null, isTracking: false };
+    }
+
+    const { height: H, width: W } = image;
+    this.frameId += 1;
+
+    let [xPatchArr, resizeFactor] = this._sampleTarget(
+      image,
+      this.currentXywh,
+      this.searchFactor,
+      this.searchSize
+    );
+    if (this.debug) {
+      this.rawSearch = xPatchArr;
+    }
+
+    let search = normalize(xPatchArr);
+    let [predBoxes, predScore] = await this._forward(
+      this.template,
+      this.onlineTemplate,
+      search
+    );
+    let predBox = predBoxes.map((x) => (x * this.searchSize) / resizeFactor);
+    this.currentXywh = this._clipBox(
+      this._mapBoxBack(predBox, resizeFactor),
+      H,
+      W,
+      10
+    );
+
+    this.maxPredScore *= this.maxScoreDecay;
+
+    // update the template
+    if (
+      predScore > this.minConfidenceThreshold &&
+      predScore > this.maxPredScore
+    ) {
+      let [zPatchArr, _] = this._sampleTarget(
+        image,
+        this.currentXywh,
+        this.templateFactor,
+        this.templateSize
+      );
+      if (this.debug) {
+        this.rawOnlineMaxTemplate = zPatchArr;
+      }
+
+      this.onlineMaxTemplate = normalize(zPatchArr);
+      this.maxPredScore = predScore;
+    }
+
+    if (predScore < this.minConfidenceThreshold) {
+      this.numConsecutiveFailures += 1;
+      return {
+        detection: null,
+        isTracking: this.isTracking(),
+      };
+    }
+
+    this.numConsecutiveFailures = 0;
+
+    if (this.frameId % this.updateInterval === 0) {
+      if (this.debug) {
+        this.rawOnlineTemplate = this.rawOnlineMaxTemplate;
+      }
+      this.onlineTemplate = this.onlineMaxTemplate;
+      this.maxPredScore = -1;
+      this.onlineMaxTemplate = this.template;
+    }
+
+    // Normalize coordinates
+    let [absX, absY, absW, absH] = this.currentXywh;
+    const detection = new Detection(
+      this.label,
+      new Box(
+        new Position(absX / W, absY / H, predScore),
+        new Position((absX + absW) / W, (absY + absH) / H, predScore)
+      ),
+      predScore
+    );
+    return { detection, isTracking: true };
+  }
+
+  _sigmoid = (x) => 1 / (1 + Math.exp(-x));
 
   _forward = async (template, onlineTemplate, search) => {
     const ort = await getOrt();
-    const toTensor = ({width, height, getData}) => {
-        const nchw = new Float32Array(getData({ channelsFirst: true }));
-        return new ort.Tensor("float32", nchw, [ 1, 3, height, width ]);
-    }
-    console.log("Running inference...");
-    const output = await this.onnxModel.run({
-        template: toTensor(template),
-        online_template: toTensor(onlineTemplate),
-        search: toTensor(search),
+    const toTensor = ({ width, height, getData }) => {
+      const nchw = new Float32Array(getData({ channelsFirst: true }));
+      return new ort.Tensor("float32", nchw, [1, 3, height, width]);
+    };
+    const output = await this.onnxSession.run({
+      template: toTensor(template),
+      online_template: toTensor(onlineTemplate),
+      search: toTensor(search),
     });
-    console.log(`output = ${JSON.stringify(output)}`);
     let { boxes, scores } = output;
-    console.log(`boxes = ${JSON.stringify(boxes)}`);
-    console.log(`scores = ${JSON.stringify(scores)}`);
     boxes = boxes.reshape([4]);
-    const score = this.sigmoid(scores.reshape([1]).data[0]);
+    const score = this._sigmoid(scores.reshape([1]).data[0]);
     return [tensorToMatrix(boxes), score];
-  }
+  };
 
   /**
    * Extracts a square crop centered at target_bb box, of area search_area_factor^2 times target_bb area
@@ -79,139 +225,51 @@ export class MixFormerObjectTracker {
    * @param {*} image
    * @param {*} bbox
    * @param {*} factor
-   * @param {*} output_sz
+   * @param {*} outputSize
    */
-  _sampleTarget = (image, bbox, search_area_factor, output_sz) => {
+  _sampleTarget = (image, bbox, searchAreaFactor, outputSize) => {
     const [x, y, w, h] = bbox;
-    // crop image
-    const crop_sz = Math.ceil(Math.sqrt(w * h) * search_area_factor);
-    console.log(`w = ${w}, h = ${h}; crop_sz = ${crop_sz}`);
-    if (crop_sz < 1) {
+    const cropSize = Math.ceil(Math.sqrt(w * h) * searchAreaFactor);
+    if (cropSize < 1) {
       throw new Error("Too small bounding box.");
     }
 
-    const x1 = Math.round(x + 0.5 * w - crop_sz * 0.5);
-    const x2 = x1 + crop_sz;
+    const x1 = Math.round(x + 0.5 * w - cropSize * 0.5);
+    const x2 = x1 + cropSize;
 
-    const y1 = Math.round(y + 0.5 * h - crop_sz * 0.5);
-    const y2 = y1 + crop_sz;
+    const y1 = Math.round(y + 0.5 * h - cropSize * 0.5);
+    const y2 = y1 + cropSize;
 
     const { width, height } = image;
 
-    const x1_pad = Math.max(0, -x1);
-    const x2_pad = Math.max(x2 - width + 1, 0);
+    const leftPad = Math.max(0, -x1);
+    const rightPad = Math.max(x2 - width + 1, 0);
 
-    const y1_pad = Math.max(0, -y1);
-    const y2_pad = Math.max(y2 - height + 1, 0);
+    const topPad = Math.max(0, -y1);
+    const bottomPad = Math.max(y2 - height + 1, 0);
 
-    console.log(
-      `centerCrop: {${x1}, ${y1}, ${x2}, ${y2}}; padding: ${x1_pad}, ${y1_pad}, ${x2_pad}, ${y2_pad}; crop_sz = ${crop_sz}`
-    );
-    var _cropped = crop(image,
-      { x1: x1 + x1_pad, y1: y1 + y1_pad, x2: x2 - x2_pad, y2: y2 - y2_pad },
-    );
-    this._croppedRaw = resize(_cropped, { width: output_sz, height: output_sz });
-    var cropped = copyMakeBorder(_cropped, {
-      top: y1_pad,
-      bottom: y2_pad,
-      left: x1_pad,
-      right: x2_pad,
+    var _cropped = crop(image, {
+      x1: x1 + leftPad,
+      y1: y1 + topPad,
+      x2: x2 - rightPad,
+      y2: y2 - bottomPad,
     });
-    const resizeFactor = output_sz / crop_sz;
-    const output = resize(cropped, { width: output_sz, height: output_sz });
+
+    var cropped = copyMakeBorder(_cropped, {
+      top: topPad,
+      bottom: bottomPad,
+      left: leftPad,
+      right: rightPad,
+    });
+    const resizeFactor = outputSize / cropSize;
+    const output = resize(cropped, { width: outputSize, height: outputSize });
     return [output, resizeFactor];
   };
 
-  _preprocess = (image) => {
-    return normalize(image);
-  };
-
-  init = async (image, bbox, label) => {
-    const { x1: x, y1: y, x2: _x2, y2: _y2 } = bbox;
-    const [w, h] = [_x2 - x, _y2 - y];
-    const xywh = [x, y, w, h];
-    const [zPatchArray, _] = this._sampleTarget(
-      image,
-      xywh,
-      this.templateFactor,
-      this.templateSize
-    );
-    this.rawTemplate = zPatchArray;
-    const template = this._preprocess(zPatchArray);
-    this.template = template;
-    this.rawOnlineTemplate = zPatchArray;
-    this.onlineTemplate = template;
-
-    this.maxPredScore = -1.0;
-    this.onlineMaxTemplate = template;
-
-    // save states
-    this.state = xywh;
-    this.frameId = 0;
-    this.label = label;
-  };
-
-  async update(image) {
-    const {height: H, width: W} = image;
-    this.frameId += 1;
-
-    let [xPatchArr, resizeFactor] = this._sampleTarget(
-      image,
-      this.state,
-      this.searchFactor,
-      this.searchSize
-    );
-    this.rawSearch = xPatchArr;
-
-    let search = this._preprocess(xPatchArr);
-    let [predBoxes, predScore] = await this._forward(
-      this.template,
-      this.onlineTemplate,
-      search
-    );
-    let predBox = predBoxes.map((x) => (x * this.searchSize) / resizeFactor);
-    console.log(`[FRAME ${this.frameId}] predBox = ${JSON.stringify(predBox)}`);
-    console.log(`[FRAME ${this.frameId}] predScore = ${JSON.stringify(predScore)}`);
-
-    this.state = this._clipBox(this._mapBoxBack(predBox, resizeFactor), H, W, 10);
-    console.log(`[FRAME ${this.frameId}] this.state = ${JSON.stringify(this.state)}`);
-
-    this.maxPredScore *= this.maxScoreDecay;
-
-    if (predScore > 0.5 && predScore > this.maxPredScore) {
-      let [zPatchArr, _] = this._sampleTarget(
-        image,
-        this.state,
-        this.templateFactor,
-        this.templateSize
-      );
-      this.rawOnlineMaxTemplate = zPatchArr;
-
-      this.onlineMaxTemplate = this._preprocess(zPatchArr);
-      this.maxPredScore = predScore;
-    }
-
-    if (this.frameId % this.updateInterval === 0) {
-      this.rawOnlineTemplate = this.rawOnlineMaxTemplate;
-      this.onlineTemplate = this.onlineMaxTemplate;
-      this.maxPredScore = -1;
-      this.onlineMaxTemplate = this.template;
-    }
-
-    let [absX, absY, absW, absH] = this.state;
-    return new Detection(
-        this.label,
-        new Box(
-            new Position(absX / W, absY / H, predScore),
-            new Position((absX + absW) / W, (absY + absH) / H, predScore),
-        ),
-        predScore,
-    );
-  }
-
+  // Map the outpout back to the original image coordinates
   _mapBoxBack(predBox, resizeFactor) {
-    let cxPrev = this.state[0] + 0.5 * this.state[2];
-    let cyPrev = this.state[1] + 0.5 * this.state[3];
+    let cxPrev = this.currentXywh[0] + 0.5 * this.currentXywh[2];
+    let cyPrev = this.currentXywh[1] + 0.5 * this.currentXywh[3];
 
     let [cx, cy, w, h] = predBox;
     let halfSide = (0.5 * this.searchSize) / resizeFactor;
@@ -221,7 +279,7 @@ export class MixFormerObjectTracker {
     return [cxReal - 0.5 * w, cyReal - 0.5 * h, w, h];
   }
 
-  _clipBox(box, H, W, margin=0) {
+  _clipBox(box, H, W, margin = 0) {
     var [x1, y1, w, h] = box;
     var [x2, y2] = [x1 + w, y1 + h];
     x1 = Math.min(Math.max(0, x1), W - margin);
@@ -232,5 +290,4 @@ export class MixFormerObjectTracker {
     h = Math.max(margin, y2 - y1);
     return [x1, y1, w, h];
   }
-
 }

--- a/object_tracking.mjs
+++ b/object_tracking.mjs
@@ -1,0 +1,236 @@
+import { tensorToMatrix } from "./inference_utils.mjs";
+import { Box, Position } from "./core_types.mjs";
+import { getOrt } from "./onnxruntime.mjs";
+import { resize, crop, copyMakeBorder, normalize } from "./preprocess.mjs";
+
+export class Detection {
+  constructor(label, box, confidence) {
+    this.label = label;
+    this.box = box;
+    this.confidence = confidence;
+  }
+}
+
+export class MixFormerObjectTracker {
+  /**
+   * @param {InferenceSession} onnxModel
+   * @param {Object} options
+   */
+
+  constructor(
+    onnxModel,
+    {
+      templateFactor = 2.0,
+      templateSize = 112,
+      searchFactor = 4.5,
+      searchSize = 224,
+      updateInterval = 10,
+      maxScoreDecay = 1.0,
+    } = {}
+  ) {
+    this.onnxModel = onnxModel;
+    this.templateFactor = templateFactor;
+    this.templateSize = templateSize;
+    this.searchFactor = searchFactor;
+    this.searchSize = searchSize;
+    this.updateInterval = updateInterval;
+    this.maxScoreDecay = maxScoreDecay;
+
+    this.state = null;
+    this.frame_id = 0;
+    this.label = null;
+  }
+
+  sigmoid = (x) => 1 / (1 + Math.exp(-x));
+
+  _forward = async (template, onlineTemplate, search) => {
+    const ort = await getOrt();
+    const toTensor = ({width, height, getData}) => {
+        const nchw = new Float32Array(getData({ channelsFirst: true }));
+        return new ort.Tensor("float32", nchw, [ 1, 3, height, width ]);
+    }
+    console.log("Running inference...");
+    const output = await this.onnxModel.run({
+        template: toTensor(template),
+        online_template: toTensor(onlineTemplate),
+        search: toTensor(search),
+    });
+    console.log(`output = ${JSON.stringify(output)}`);
+    let { boxes, scores } = output;
+    console.log(`boxes = ${JSON.stringify(boxes)}`);
+    console.log(`scores = ${JSON.stringify(scores)}`);
+    boxes = boxes.reshape([4]);
+    const score = this.sigmoid(scores.reshape([1]).data[0]);
+    return [tensorToMatrix(boxes), score];
+  }
+
+  /**
+   * Extracts a square crop centered at target_bb box, of area search_area_factor^2 times target_bb area
+   *  args:
+   *      im - cv image
+   *      target_bb - target box [x, y, w, h]
+   *      search_area_factor - Ratio of crop size to target size
+   *      output_sz - (float) Size to which the extracted crop is resized (always square).
+   *
+   *  returns:
+   *      cv image - extracted crop
+   *      float - the factor by which the crop has been resized to make the crop size equal output_size
+   *
+   * @param {*} image
+   * @param {*} bbox
+   * @param {*} factor
+   * @param {*} output_sz
+   */
+  _sampleTarget = (image, bbox, search_area_factor, output_sz) => {
+    const [x, y, w, h] = bbox;
+    // crop image
+    const crop_sz = Math.ceil(Math.sqrt(w * h) * search_area_factor);
+    console.log(`w = ${w}, h = ${h}; crop_sz = ${crop_sz}`);
+    if (crop_sz < 1) {
+      throw new Error("Too small bounding box.");
+    }
+
+    const x1 = Math.round(x + 0.5 * w - crop_sz * 0.5);
+    const x2 = x1 + crop_sz;
+
+    const y1 = Math.round(y + 0.5 * h - crop_sz * 0.5);
+    const y2 = y1 + crop_sz;
+
+    const { width, height } = image;
+
+    const x1_pad = Math.max(0, -x1);
+    const x2_pad = Math.max(x2 - width + 1, 0);
+
+    const y1_pad = Math.max(0, -y1);
+    const y2_pad = Math.max(y2 - height + 1, 0);
+
+    console.log(
+      `centerCrop: {${x1}, ${y1}, ${x2}, ${y2}}; padding: ${x1_pad}, ${y1_pad}, ${x2_pad}, ${y2_pad}; crop_sz = ${crop_sz}`
+    );
+    var _cropped = crop(image,
+      { x1: x1 + x1_pad, y1: y1 + y1_pad, x2: x2 - x2_pad, y2: y2 - y2_pad },
+    );
+    this._croppedRaw = resize(_cropped, { width: output_sz, height: output_sz });
+    var cropped = copyMakeBorder(_cropped, {
+      top: y1_pad,
+      bottom: y2_pad,
+      left: x1_pad,
+      right: x2_pad,
+    });
+    const resizeFactor = output_sz / crop_sz;
+    const output = resize(cropped, { width: output_sz, height: output_sz });
+    return [output, resizeFactor];
+  };
+
+  _preprocess = (image) => {
+    return normalize(image);
+  };
+
+  init = async (image, bbox, label) => {
+    const { x1: x, y1: y, x2: _x2, y2: _y2 } = bbox;
+    const [w, h] = [_x2 - x, _y2 - y];
+    const xywh = [x, y, w, h];
+    const [zPatchArray, _] = this._sampleTarget(
+      image,
+      xywh,
+      this.templateFactor,
+      this.templateSize
+    );
+    this.rawTemplate = zPatchArray;
+    const template = this._preprocess(zPatchArray);
+    this.template = template;
+    this.rawOnlineTemplate = zPatchArray;
+    this.onlineTemplate = template;
+
+    this.maxPredScore = -1.0;
+    this.onlineMaxTemplate = template;
+
+    // save states
+    this.state = xywh;
+    this.frameId = 0;
+    this.label = label;
+  };
+
+  async update(image) {
+    const {height: H, width: W} = image;
+    this.frameId += 1;
+
+    let [xPatchArr, resizeFactor] = this._sampleTarget(
+      image,
+      this.state,
+      this.searchFactor,
+      this.searchSize
+    );
+    this.rawSearch = xPatchArr;
+
+    let search = this._preprocess(xPatchArr);
+    let [predBoxes, predScore] = await this._forward(
+      this.template,
+      this.onlineTemplate,
+      search
+    );
+    let predBox = predBoxes.map((x) => (x * this.searchSize) / resizeFactor);
+    console.log(`[FRAME ${this.frameId}] predBox = ${JSON.stringify(predBox)}`);
+    console.log(`[FRAME ${this.frameId}] predScore = ${JSON.stringify(predScore)}`);
+
+    this.state = this._clipBox(this._mapBoxBack(predBox, resizeFactor), H, W, 10);
+    console.log(`[FRAME ${this.frameId}] this.state = ${JSON.stringify(this.state)}`);
+
+    this.maxPredScore *= this.maxScoreDecay;
+
+    if (predScore > 0.5 && predScore > this.maxPredScore) {
+      let [zPatchArr, _] = this._sampleTarget(
+        image,
+        this.state,
+        this.templateFactor,
+        this.templateSize
+      );
+      this.rawOnlineMaxTemplate = zPatchArr;
+
+      this.onlineMaxTemplate = this._preprocess(zPatchArr);
+      this.maxPredScore = predScore;
+    }
+
+    if (this.frameId % this.updateInterval === 0) {
+      this.rawOnlineTemplate = this.rawOnlineMaxTemplate;
+      this.onlineTemplate = this.onlineMaxTemplate;
+      this.maxPredScore = -1;
+      this.onlineMaxTemplate = this.template;
+    }
+
+    let [absX, absY, absW, absH] = this.state;
+    return new Detection(
+        this.label,
+        new Box(
+            new Position(absX / W, absY / H, predScore),
+            new Position((absX + absW) / W, (absY + absH) / H, predScore),
+        ),
+        predScore,
+    );
+  }
+
+  _mapBoxBack(predBox, resizeFactor) {
+    let cxPrev = this.state[0] + 0.5 * this.state[2];
+    let cyPrev = this.state[1] + 0.5 * this.state[3];
+
+    let [cx, cy, w, h] = predBox;
+    let halfSide = (0.5 * this.searchSize) / resizeFactor;
+    let cxReal = cx + (cxPrev - halfSide);
+    let cyReal = cy + (cyPrev - halfSide);
+
+    return [cxReal - 0.5 * w, cyReal - 0.5 * h, w, h];
+  }
+
+  _clipBox(box, H, W, margin=0) {
+    var [x1, y1, w, h] = box;
+    var [x2, y2] = [x1 + w, y1 + h];
+    x1 = Math.min(Math.max(0, x1), W - margin);
+    x2 = Math.min(Math.max(margin, x2), W);
+    y1 = Math.min(Math.max(0, y1), H - margin);
+    y2 = Math.min(Math.max(margin, y2), H);
+    w = Math.max(margin, x2 - x1);
+    h = Math.max(margin, y2 - y1);
+    return [x1, y1, w, h];
+  }
+
+}

--- a/preprocess.mjs
+++ b/preprocess.mjs
@@ -276,7 +276,7 @@ const copyMakeBorder = (
   const dstHeight = srcHeight + top + bottom;
   const data = image.getData({ channelsFirst: false });
 
-  const ArrayType = arr.constructor;
+  const ArrayType = data.constructor;
   let output = new ArrayType(dstWidth * dstHeight * image.numChannels);
 
   for (var row = 0; row < srcHeight; row++) {

--- a/preprocess.mjs
+++ b/preprocess.mjs
@@ -250,8 +250,8 @@ const normalize = (image) => {
   const output = new Float32Array(3 * height * width);
 
   // if input is integer in [0,255], convert to float32 in [0,1]
-  const isUint8 = hwc.some((x) => x % 1 !== 0);
-  const normFactor = isUint8 ? 1 : 255.0;
+  const isFloat = hwc.some((x) => x % 1 !== 0);
+  const normFactor = isFloat ? 1 : 255.0;
 
   // rgb
   const mean = [0.48145466, 0.4578275, 0.40821073];

--- a/preprocess.mjs
+++ b/preprocess.mjs
@@ -1,8 +1,4 @@
 const Mat = ({ data, width, height, format }) => {
-  // if (!Array.isArray(data)) {
-  //   throw new Error(`Unsupported data type: ${typeof data}`);
-  // }
-
   if (!(height > 0 && width > 0)) {
     throw new Error(`Invalid dimensions: ${width}x${height}`);
   }
@@ -90,8 +86,13 @@ const ensureRgbMat = (imgOrMat) => {
   if (imgOrMat.getData) {
     mat = imgOrMat;
   } else {
-    const numChannels = Math.round(imgOrMat.data.length / (imgOrMat.width * imgOrMat.height));
-    console.assert(Number.isInteger(numChannels));
+    const numChannels = Math.round(
+      imgOrMat.data.length / (imgOrMat.width * imgOrMat.height)
+    );
+    if (!(numChannels === 3 || numChannels === 4)) {
+      throw new Error(`Unsupported number of channels: ${numChannels}`);
+    }
+
     mat = Mat({
       data: imgOrMat.data,
       height: imgOrMat.height,
@@ -219,7 +220,6 @@ const centerCrop = (
   const xOffset = targetWidth / 2 - centerCropX * scale;
   const yOffset = targetHeight / 2 - centerCropY * scale;
 
-  // const _max = output.reduce((acc, val) => (acc > val ? acc : val));
   return {
     image: Mat({
       data: output,
@@ -245,38 +245,22 @@ const centerCrop = (
 const normalize = (image) => {
   image = ensureRgbMat(image);
 
-  // const isUInt8 = (data) => {
-  //   // Note: we can't use Math.max() because it results in "Maximum call stack size exceeded"
-  //   let isUInt8 = false;
-  //   for (let i = 0; i < data.length; i++) {
-  //     if (data[i] > 1) {
-  //       isUInt8 = true;
-  //       break;
-  //     }
-  //   }
-  //   return isUInt8;
-  // };
+  const { width, height, numChannels } = image;
+  const hwc = image.getData({ channelsFirst: false });
+  const output = new Float32Array(3 * height * width);
 
   // if input is integer in [0,255], convert to float32 in [0,1]
-  let hwc = image.getData({ channelsFirst: false });
-  const isUint8 = (arr) => arr.some((x) => x > 1);
-  if (isUint8(hwc)) {
-    hwc = new Float32Array(hwc).map((x) => x / 255.0);
-    // hwc = hwc.map((x) => x / 255.0);
-  }
+  const isUint8 = hwc.some((x) => x % 1 !== 0);
+  const normFactor = isUint8 ? 1 : 255.0;
 
-  let { width, height, numChannels } = image;
-  const outputChannels = 3;
-  const output = new Float32Array(outputChannels * height * width);
-
-  // TODO: is this rgb or bgr?
+  // rgb
   const mean = [0.48145466, 0.4578275, 0.40821073];
   const std = [0.26862954, 0.26130258, 0.27577711];
 
   for (let i = 0; i < hwc.length; i += numChannels) {
-    output[i + 0] = (hwc[i + 0] - mean[0]) / std[0];
-    output[i + 1] = (hwc[i + 1] - mean[1]) / std[1];
-    output[i + 2] = (hwc[i + 2] - mean[2]) / std[2];
+    output[i + 0] = (hwc[i + 0] / normFactor - mean[0]) / std[0];
+    output[i + 1] = (hwc[i + 1] / normFactor - mean[1]) / std[1];
+    output[i + 2] = (hwc[i + 2] / normFactor - mean[2]) / std[2];
   }
   return Mat({ data: output, width, height, format: "RGB" });
 };
@@ -292,14 +276,8 @@ const copyMakeBorder = (
   const dstHeight = srcHeight + top + bottom;
   const data = image.getData({ channelsFirst: false });
 
-  let output;
-  if (data instanceof Uint8ClampedArray) {
-    output = new Uint8ClampedArray(dstWidth * dstHeight * image.numChannels);
-  } else if (data instanceof Float32Array) {
-    output = new Float32Array(dstWidth * dstHeight * image.numChannels);
-  } else {
-    throw new Error(`Unsupported data type: ${typeof data}`);
-  }
+  const ArrayType = arr.constructor;
+  let output = new ArrayType(dstWidth * dstHeight * image.numChannels);
 
   for (var row = 0; row < srcHeight; row++) {
     for (var col = 0; col < srcWidth; col++) {
@@ -323,7 +301,7 @@ const copyMakeBorder = (
   });
 };
 
-const resize = (image, { width: newWidth, height: newHeight}) => {
+const resize = (image, { width: newWidth, height: newHeight }) => {
   image = ensureRgbMat(image);
   const { numChannels, width, height } = image;
   const arr = image.getData({ channelsFirst: false });
@@ -335,26 +313,25 @@ const resize = (image, { width: newWidth, height: newHeight}) => {
   const yRatio = height / newHeight;
 
   for (let y = 0; y < newHeight; y++) {
-      const newY = Math.floor(y * yRatio);
-      for (let x = 0; x < newWidth; x++) {
-          const newX = Math.floor(x * xRatio);
+    const newY = Math.floor(y * yRatio);
+    for (let x = 0; x < newWidth; x++) {
+      const newX = Math.floor(x * xRatio);
 
-          for (let c = 0; c < numChannels; c++) {
-              const newIdx = (y * newWidth + x) * numChannels + c;
-              const originalIdx = (newY * width + newX) * numChannels + c;
+      for (let c = 0; c < numChannels; c++) {
+        const newIdx = (y * newWidth + x) * numChannels + c;
+        const originalIdx = (newY * width + newX) * numChannels + c;
 
-              newArr[newIdx] = arr[originalIdx];
-          }
+        newArr[newIdx] = arr[originalIdx];
       }
+    }
   }
 
   return Mat({
-      data: newArr,
-      width: newWidth,
-      height: newHeight,
-      format: image.format,
+    data: newArr,
+    width: newWidth,
+    height: newHeight,
+    format: image.format,
   });
-}
-
+};
 
 export { centerCrop, crop, normalize, copyMakeBorder, resize };


### PR DESCRIPTION
Add MixFormerv2 object tracker implementation.

I had to add a `resize()` and `copyMakeBorder()` function to the the preprocessing module.
Both work similarly to OpenCV's implementation, albeit with fewer knobs to tune.

I also fixed a bug where `normalize()` didn't properly handle images with type UInt8Array.

Example schema: http://console.getguru.ai/editor?schemaId=11ea0ebb-d8a2-4412-a221-98ac8f669cd4&videoId=9d875854-a105-418a-b856-3a9ee621e774

(This is in the automated_test tenant).